### PR TITLE
feat: Support adding and removing allocations

### DIFF
--- a/client/src/ConfigurationPage.tsx
+++ b/client/src/ConfigurationPage.tsx
@@ -37,7 +37,13 @@ export default function ConfigurationPage(): JSX.Element {
     return (
         <div>
             <h1>Account Configuration</h1>
-            {portfolioDetails != null && (<PortfolioConfig onPortfolioUpdate={handlePortfolioUpdate} {...portfolioDetails} />)}
+            {portfolioDetails != null && (
+                <PortfolioConfig
+                    onPortfolioUpdate={handlePortfolioUpdate}
+                    initialAllocations={portfolioDetails.allocations}
+                    {...portfolioDetails}
+                />
+            )}
             {showApiKeyForm && (
                 <ApiKeyForm
                     onSuccess={(portfolio) => {

--- a/client/src/HttpUtils.ts
+++ b/client/src/HttpUtils.ts
@@ -7,7 +7,8 @@ async function postJson(url = '', data = {}): Promise<Response> {
         cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
         credentials: 'same-origin', // include, *same-origin, omit
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
         },
         redirect: 'follow', // manual, *follow, error
         referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
@@ -23,7 +24,8 @@ async function getJson(url = ''): Promise<Response> {
         cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
         credentials: 'same-origin', // include, *same-origin, omit
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
         },
         redirect: 'follow', // manual, *follow, error
         referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url

--- a/client/src/PortfolioConfig.tsx
+++ b/client/src/PortfolioConfig.tsx
@@ -1,19 +1,23 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, TextField, Button, CircularProgress } from '@material-ui/core';
+import { Autocomplete } from '@material-ui/lab';
 import EditIcon from '@material-ui/icons/Edit';
 import SaveIcon from '@material-ui/icons/Save';
+import AddIcon from '@material-ui/icons/Add';
 
 import { AssetAllocation, PortfolioAPI } from './api/PortfolioData';
+import { Product, CoinbaseProAPI } from './api/CoinbaseProData';
 
 interface AssetAllocationConfigProps {
     productId: string;
+    displayName: string;
     dailyTargetAmount: number;
 }
 
 interface PortfolioConfigProps {
     id: string;
     displayName: string;
-    allocations: AssetAllocation[];
+    initialAllocations: AssetAllocation[];
     onPortfolioUpdate: () => Promise<void>;
 }
 
@@ -23,7 +27,7 @@ function AssetAllocationRow(props: AssetAllocationConfigProps): JSX.Element {
         // sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
         >
             <TableCell component="th" scope="row">
-                {props.productId}
+                {props.displayName}
             </TableCell>
             <TableCell align="center">{props.dailyTargetAmount}</TableCell>
         </TableRow>
@@ -51,7 +55,7 @@ function EditableAssetAllocationRow(props: EditableAssetAllocationRowProps): JSX
     return (
         <TableRow>
             <TableCell component="th" scope="row">
-                {props.productId}
+                {props.displayName}
             </TableCell>
             <TableCell align="center">
                 <TextField
@@ -63,28 +67,117 @@ function EditableAssetAllocationRow(props: EditableAssetAllocationRowProps): JSX
     );
 };
 
+interface NewAssetAllocationRowProps {
+    options: Product[];
+    onSubmitAssetAddition: (asset: Product) => void;
+}
+
+function NewAssetAllocationRow(props: NewAssetAllocationRowProps): JSX.Element {
+    const [selectedOption, setSelectedOption] = useState<Product | null>(null);
+    const [inputValue, setInputValue] = useState('');
+
+    return (
+        <TableRow>
+            <TableCell>
+                <Autocomplete
+                    onChange={(event, newValue) => {
+                        setSelectedOption(newValue);
+                    }}
+                    inputValue={inputValue}
+                    onInputChange={(event, newInputValue) => {
+                        setInputValue(newInputValue);
+                    }}
+                    options={props.options}
+                    getOptionLabel={(option) => option.displayName}
+                    style={{ width: 300 }}
+                    renderInput={(params) => <TextField {...params} label="Add asset" variant="outlined" />}
+                    selectOnFocus
+                    clearOnBlur
+                    handleHomeEndKeys
+                />
+            </TableCell>
+            {selectedOption !== null && (
+                <TableCell>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={() => {
+                            props.onSubmitAssetAddition(selectedOption);
+                            setInputValue(''); // Clear the input box to make space for additional entries
+                        }}
+                        endIcon={<AddIcon />}
+                    />
+                </TableCell>
+            )}
+        </TableRow>
+    );
+}
+
+type ProductId = Product["id"];
+
 function PortfolioConfig(props: PortfolioConfigProps): JSX.Element {
+    const [allProducts, setAllProducts] = useState<Product[] | null>(null);
+    const [productsById, setProductsById] = useState<{ [key: ProductId]: Product } | null>(null);
+
     const [editing, setEditing] = useState<boolean>(false);
     const [saving, setSaving] = useState<boolean>(false);
-    const [updatedAllocations, setUpdatedAllocations] = useState<{ [key: string]: number }>(
-        Object.fromEntries<number>(props.allocations.map(allocation => [allocation.productId, allocation.dailyTargetAmount]))
+
+    const [allocationAmounts, setAllocationAmounts] = useState<{ [key: string]: number }>(
+        Object.fromEntries<number>(props.initialAllocations.map(allocation => [allocation.productId, allocation.dailyTargetAmount]))
     );
+    const [addedAllocations, setAddedAllocations] = useState<ProductId[]>([]);
+
+    useEffect(() => {
+        CoinbaseProAPI.getAvailableProducts()
+            .then(products => {
+                setAllProducts(products);
+                setProductsById(
+                    Object.fromEntries<Product>(products.map(product => [product.id, product]))
+                )
+            })
+    }, []);
 
     const handleUpdateAllocation = (productId: string) => {
         return (updatedDailyAmount: number) => {
-            setUpdatedAllocations({ ...updatedAllocations, [productId]: updatedDailyAmount });
+            setAllocationAmounts({ ...allocationAmounts, [productId]: updatedDailyAmount });
         };
     }
 
     const handleSave = () => {
         const apiPromises = new Array<Promise<void>>();
-        for (let originalAllocation of props.allocations) {
-            let productId = originalAllocation.productId;
-            if (originalAllocation.dailyTargetAmount !== updatedAllocations[productId]) {
+        // Update or remove initial allocations
+        for (const originalAllocation of props.initialAllocations) {
+            const productId = originalAllocation.productId;
+            if (originalAllocation.dailyTargetAmount !== allocationAmounts[productId]) {
+                if (allocationAmounts[productId] > 0) {
+                    apiPromises.push(
+                        PortfolioAPI.setAssetAllocation(
+                            props.id,
+                            { productId, dailyTargetAmount: allocationAmounts[productId] },
+                            () => { },
+                            () => { },
+                            () => { }
+                        ));
+                } else {
+                    apiPromises.push(
+                        PortfolioAPI.removeAssetAllocation(
+                            props.id,
+                            productId,
+                            () => { },
+                            () => { },
+                            () => { }
+                        ));
+                }
+            }
+        }
+        // Set new allocations
+        for (const productId of addedAllocations) {
+            const allocationAmount = allocationAmounts[productId];
+            if (allocationAmount > 0) {
                 apiPromises.push(
                     PortfolioAPI.setAssetAllocation(
                         props.id,
-                        { productId, dailyTargetAmount: updatedAllocations[productId] },
+                        { productId, dailyTargetAmount: allocationAmount },
                         () => { },
                         () => { },
                         () => { }
@@ -96,10 +189,20 @@ function PortfolioConfig(props: PortfolioConfigProps): JSX.Element {
         Promise.all(apiPromises).finally(() => {
             props.onPortfolioUpdate().finally(() => {
                 setSaving(false);
+                setAddedAllocations([]);
             });
         })
     }
 
+    if (allProducts === null || productsById === null) {
+        return (
+            <div>
+                <CircularProgress />
+            </div>
+        );
+    }
+
+    const currentAllocatedProductIds = props.initialAllocations.map(allocation => allocation.productId).concat(addedAllocations);
     return (
         <div>
             <TableContainer component={Paper}>
@@ -112,19 +215,31 @@ function PortfolioConfig(props: PortfolioConfigProps): JSX.Element {
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        {props.allocations.map((allocation) => (
+                        {currentAllocatedProductIds.map((productId) => (
                             editing ?
                                 <EditableAssetAllocationRow
-                                    key={allocation.productId}
-                                    onDailyAmountUpdate={handleUpdateAllocation(allocation.productId)}
-                                    {...allocation}
+                                    key={productId}
+                                    productId={productId}
+                                    displayName={productsById[productId].displayName}
+                                    dailyTargetAmount={allocationAmounts[productId]}
+                                    onDailyAmountUpdate={handleUpdateAllocation(productId)}
                                 /> :
                                 <AssetAllocationRow
-                                    key={allocation.productId}
-                                    productId={allocation.productId}
-                                    dailyTargetAmount={updatedAllocations[allocation.productId]}
+                                    key={productId}
+                                    productId={productId}
+                                    displayName={productsById[productId].displayName}
+                                    dailyTargetAmount={allocationAmounts[productId]}
                                 />
                         ))}
+                        {editing && (
+                            <NewAssetAllocationRow
+                                options={allProducts.filter(product => !currentAllocatedProductIds.includes(product.id))}
+                                onSubmitAssetAddition={(product) => {
+                                    setAddedAllocations(prevAddedAllocations => [...prevAddedAllocations, product.id]);
+                                    setAllocationAmounts({ ...allocationAmounts, [product.id]: 0 });
+                                }}
+                            />
+                        )}
                     </TableBody>
                 </Table>
             </TableContainer>

--- a/client/src/api/CoinbaseProData.ts
+++ b/client/src/api/CoinbaseProData.ts
@@ -1,0 +1,45 @@
+import { getJson } from '../HttpUtils';
+
+const COINBASE_PRO_API_URL_BASE = 'https://api.exchange.coinbase.com';
+const ALL_PRODUCTS_URL = `${COINBASE_PRO_API_URL_BASE}/products`;
+
+interface Product {
+    id: string;
+    displayName: string;
+    minimumPurchaseAmount: number;
+}
+
+function _isSupportedProduct(productJson: any): boolean {
+    return (
+        !productJson['trading_disabled'] &&
+        !productJson['auction_mode'] &&
+        !productJson['post_only'] &&
+        !productJson['limit_only'] &&
+        !productJson['cancel_only'] &&
+        productJson['quote_currency'] === 'USD'
+    )
+}
+
+function _productFromJson(productJson: any): Product {
+    return {
+        id: productJson['id'],
+        displayName: productJson['base_currency'],
+        minimumPurchaseAmount: productJson['min_market_funds']
+    };
+}
+
+class CoinbaseProAPI {
+    static getAvailableProducts(): Promise<Product[]> {
+        return getJson(ALL_PRODUCTS_URL)
+            .then(response => response.json())
+            .then((productsJson: any[]) => productsJson
+                .filter(_isSupportedProduct)
+                .map(_productFromJson)
+                // Sort by displayName
+                .sort((a, b) => a.displayName.localeCompare(b.displayName))
+            )
+    }
+}
+
+export type { Product };
+export { CoinbaseProAPI };


### PR DESCRIPTION
This introduces support for adding and/or removing new allocations in the UI.

While editing, a new autocomplete input allows selecting an available asset. After selecting the asset, hitting the `+` button adds it as a new ($0) allocation, which can be edited prior to saving.

To remove an allocation, simply set the target amount to $0 and save.

<img width="895" alt="Screen Shot 2022-07-16 at 3 19 34 AM" src="https://user-images.githubusercontent.com/4859361/179350887-55ba3a19-9c39-4027-b52d-38df19a759ea.png">
------------
Only once a valid asset name is selected does the `+` button appear, as shown below.
<img width="674" alt="Screen Shot 2022-07-16 at 3 19 53 AM" src="https://user-images.githubusercontent.com/4859361/179350897-74e9d3e0-507c-4364-9495-e6283adfb546.png">

