### PR TITLE
feat: Add explicit savings to fee slider

### DIFF
--- a/client/src/components/FeeSlider.tsx
+++ b/client/src/components/FeeSlider.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 
-import { Container, Input, Grid, Box, Slider } from '@material-ui/core';
+import { Container, Input, InputAdornment, Grid, Box, Slider } from '@material-ui/core';
 
 import ToggleButton from '@material-ui/lab/ToggleButton';
 import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
@@ -74,6 +74,7 @@ export default function FeeSlider(): JSX.Element {
                         type: 'number',
                         'aria-labelledby': 'input-slider',
                     }}
+                    startAdornment={<InputAdornment position="start">$</InputAdornment>}
                 />
                 <Box sx={{ width: 300 }}>
                     <Slider
@@ -100,6 +101,8 @@ export default function FeeSlider(): JSX.Element {
                 <Grid item xs={4}><div>${coinbaseComFees}</div></Grid>
                 <Grid item xs={8}><div>nckl total fees:</div></Grid>
                 <Grid item xs={4}><div>${coinbaseProFees}</div></Grid>
+                <Grid item xs={8}><div><b>Your savings:</b></div></Grid>
+                <Grid item xs={4}><div><b>${coinbaseComFees - coinbaseProFees}</b></div></Grid>
             </Grid>
 
         </Container >


### PR DESCRIPTION
Adds two minor polish elements to the fees widget on the mode page:
1. A `$` prefix to the daily purchase amount input
2. An explicit `Your savings: $X` line to the fees comparison

<img width="451" alt="Screen Shot 2022-07-25 at 9 17 11 PM" src="https://user-images.githubusercontent.com/4859361/180921900-e413bb6f-aaa9-46e9-961b-a4860d05d211.png">
