### PR TITLE
feat: Request Coinbase account email

### DIFF
--- a/backend/services/api.py
+++ b/backend/services/api.py
@@ -51,7 +51,9 @@ def handle_get_or_create_user():
 
     try:
         user_params = envelope["user"]
-        user_id = get_or_create_user(user_params["provider"], user_params["id"])
+        user_id = get_or_create_user(
+            user_params["provider"], user_params["id"], user_params["email"]
+        )
     except KeyError as e:
         return (str(e), 400)
 

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -55,7 +55,9 @@ passport.deserializeUser<SerializedUser>((serUser, done) => {
 passport.use(new CoinbaseStrategy({
     clientID: process.env.COINBASE_CLIENT_ID!,
     clientSecret: process.env.COINBASE_CLIENT_SECRET!,
-    callbackURL: `${AUTH_CALLBACK_URL_BASE}/auth/coinbase/callback`
+    callbackURL: `${AUTH_CALLBACK_URL_BASE}/auth/coinbase/callback`,
+    account: 'all',
+    scope: ['wallet:user:email']
 },
     function (accessToken, refreshToken, profile, cb) {
         console.log("Received Coinbase tokens")

--- a/frontend/users.ts
+++ b/frontend/users.ts
@@ -11,6 +11,9 @@ class CoinbaseUser {
     }
 
     static getOrCreate(profile: CoinbaseProfile, onSuccess: (user: CoinbaseUser) => void, onError: (reason: any) => void) {
+        if (!profile.emails || profile.emails.length === 0) {
+            throw new Error("Expected user profile to include an email.");
+        }
         ApiService.authenticatedRequest(
             {
                 method: 'post',
@@ -18,7 +21,8 @@ class CoinbaseUser {
                 data: {
                     user: {
                         provider: 'coinbase',
-                        id: profile.id
+                        id: profile.id,
+                        email: profile.emails[0].value
                     }
                 },
                 responseType: 'json'


### PR DESCRIPTION
Makes the following changes to the Coinbase login OAuth2 auth request:
- Changes `account` from `select` to `all`: there is no point in asking the user to select a wallet, since we don't actually need any wallet permissions
- Requests the `wallet:user:email` scope

We then store the latest email associated with a user whenever there is a successful login.